### PR TITLE
Cambio de requirements para el despliegue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ djangorestframework==3.7.7
 django-cors-headers==2.1.0
 requests==2.18.4
 django-filter==1.1.0
-psycopg2==2.7.4
+psycopg2==2.8.4
 django-rest-swagger==2.2.0
 coverage==4.5.2
 django-nose==1.4.6


### PR DESCRIPTION
Se ha cambiado la versión por incompatibilidad de psycopg2 a la 2.8.4